### PR TITLE
Fix readme release reference to include -alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Java code-generation for the [OpenTelemetry Semantic Conventions](https://github
 
 Published releases are available on maven central. Replace `{{version}}` with the latest released version:
 
-![GitHub release (with filter)](https://img.shields.io/github/v/release/open-telemetry/semantic-conventions-java)
+[![Maven Central][maven-image]][maven-url]
 
 ### Maven
 


### PR DESCRIPTION
The readme references the github release version (i.e v1.21.0) instead of the artifact coordinates in maven (i.e. v1.21.0-alpha). 