### PR TITLE
Upgrade to OTEL API 1.31.x

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ nexusPublishing {
 }
 
 dependencies {
-  implementation(platform("io.opentelemetry:opentelemetry-bom:1.30.1"))
+  implementation(platform("io.opentelemetry:opentelemetry-bom:1.31.0"))
   implementation("io.opentelemetry:opentelemetry-api")
 
   testImplementation(platform("org.junit:junit-bom:5.10.0"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ nexusPublishing {
 }
 
 dependencies {
-  implementation(platform("io.opentelemetry:opentelemetry-bom:1.29.0"))
+  implementation(platform("io.opentelemetry:opentelemetry-bom:1.30.1"))
   implementation("io.opentelemetry:opentelemetry-api")
 
   testImplementation(platform("org.junit:junit-bom:5.10.0"))


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions-java/issues/25

I noticed OTEL 1.31.x is out so I upgraded directly to this version (skipping 1.30.x).