### PR TITLE
Compile only opentelemetry-api dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ dependencies {
 Java 17 or higher is required to build the projects in this repository. The built artifacts can be
 used on Java 8 or higher.
 
+To use this artifact you must also depend on `io.opentelemetry:opentelemetry-api:{{version}}`.
+See [opentelemetry-java releases](https://github.com/open-telemetry/opentelemetry-java#releases) for
+more information.
+
 ## Generating semantic conventions
 
 Requires docker.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,9 +53,12 @@ nexusPublishing {
   }
 }
 
+val opentelemetryJavaVersion = "1.31.0"
+
 dependencies {
-  implementation(platform("io.opentelemetry:opentelemetry-bom:1.31.0"))
-  implementation("io.opentelemetry:opentelemetry-api")
+  compileOnly("io.opentelemetry:opentelemetry-api:$opentelemetryJavaVersion")
+
+  testImplementation("io.opentelemetry:opentelemetry-api:$opentelemetryJavaVersion")
 
   testImplementation(platform("org.junit:junit-bom:5.10.0"))
   testImplementation("org.junit.jupiter:junit-jupiter-api")


### PR DESCRIPTION
Resolves #25.

When I `./gradlew publishToMavenLocal` I get the following in my pom file:
```
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <!-- This module was also published with a richer model, Gradle metadata,  -->
  <!-- which should be used instead. Do not delete the following line which  -->
  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
  <!-- that they should prefer consuming it instead. -->
  <!-- do_not_remove: published-with-gradle-metadata -->
  <modelVersion>4.0.0</modelVersion>
  <groupId>io.opentelemetry.semconv</groupId>
  <artifactId>opentelemetry-semconv</artifactId>
  <version>1.21.0-alpha-SNAPSHOT</version>
  <name>OpenTelemetry Semantic Conventions Java</name>
  <description>OpenTelemetry Semantic Conventions generated classes for Java</description>
  <url>https://github.com/open-telemetry/semantic-conventions-java</url>
  <licenses>
    <license>
      <name>The Apache License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
    </license>
  </licenses>
  <developers>
    <developer>
      <id>opentelemetry</id>
      <name>OpenTelemetry</name>
      <url>https://github.com/open-telemetry/community</url>
    </developer>
  </developers>
  <scm>
    <connection>scm:git:git@github.com:open-telemetry/semantic-conventions-java.git</connection>
    <developerConnection>scm:git:git@github.com:open-telemetry/semantic-conventions-java.git</developerConnection>
    <url>git@github.com:open-telemetry/semantic-conventions-java.git</url>
  </scm>
</project>
```