### PR TITLE
Fix prepare-release-branch, update changelog for 1.23.1 release

### DIFF
--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Set environment variables
         run: |
           version=$(.github/scripts/get-version.sh)
-          if [[ ! $version =~ ^([0-9]+)\.([0-9]+)\.0$ ]]; then
+          if [[ ! $version =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
             echo "unexpected version: $version"
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## Version 1.23.1 (2023-11-21)
+
 * Extended jinja template to generate template-type semantic attributes.
   ([#24](https://github.com/open-telemetry/semantic-conventions-java/pull/24))
 * Update to semconv 1.23.1


### PR DESCRIPTION
The `prepare-release-branch.yml` task partially failed preparing for the 1.23.1 release: https://github.com/open-telemetry/semantic-conventions-java/actions/runs/6950081231/job/18909546619

Apparently it expected the version to match x.x.0, though I don't see anything that depends on the patch being 0.

This PR fixes the github action and manually performs the update to `CHANGELOG.md` it performs.