### PR TITLE
Encode semconv version in build dir to fix build cache

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ val schemaUrl = "https://opentelemetry.io/schemas/$semanticConventionsVersion"
 
 val downloadSemanticConventions by tasks.registering(Download::class) {
   src(semanticConventionsRepoZip)
-  dest("$buildDir/semantic-conventions/semantic-conventions.zip")
+  dest("$buildDir/semantic-conventions-${semanticConventionsVersion}/semantic-conventions.zip")
   overwrite(false)
 }
 
@@ -69,7 +69,7 @@ val unzipConfigurationSchema by tasks.registering(Copy::class) {
     val pathParts = path.split("/")
     path = pathParts.subList(1, pathParts.size).joinToString("/")
   })
-  into("$buildDir/semantic-conventions/")
+  into("$buildDir/semantic-conventions-${semanticConventionsVersion}/")
 }
 
 fun generateTask(taskName: String, incubating: Boolean) {
@@ -88,7 +88,7 @@ fun generateTask(taskName: String, incubating: Boolean) {
     setArgs(listOf(
         "run",
         "--rm",
-        "-v", "$buildDir/semantic-conventions/model:/source",
+        "-v", "$buildDir/semantic-conventions-${semanticConventionsVersion}/model:/source",
         "-v", "$projectDir/buildscripts/templates:/templates",
         "-v", "$projectDir/$outputDir:/output",
         "otel/semconvgen:$generatorVersion",


### PR DESCRIPTION
You currently have to manually delete `./build` when changing semconv versions because the build will see the existing `/build/semantic-conventions` dir and skip downloading / unzipping the new version. This fixes it encoding the version into the dir so that the download is always triggered. 