### PR TITLE
Cleanup enum generation

### DIFF
--- a/buildscripts/templates/SemanticAttributes.java.j2
+++ b/buildscripts/templates/SemanticAttributes.java.j2
@@ -28,14 +28,15 @@
     {{type | to_camelcase(False)}}Key
   {%- endif -%}
 {%- endmacro %}
-{%- macro stable_class_ref(const_name) -%}
-{{stablePkg}}.{{ root_namespace | to_camelcase(True) }}Attributes#{{const_name}}
+{%- macro stable_class_ref(const_name, separator) -%}
+{{stablePkg}}.{{ root_namespace | to_camelcase(True) }}Attributes{{separator}}{{const_name}}
 {%- endmacro %}
 {%- if filter != 'any' %}
 {%- set filtered_attributes = attributes_and_templates | select(filter) | list %}
 {%- else %}
 {%- set filtered_attributes = attributes_and_templates | list %}
 {%- endif %}
+{%- set filtered_enums = filtered_attributes | selectattr('is_enum', 'equalto', true) | list %}
 {%- if filtered_attributes | count > 0 %}
 /*
  * Copyright The OpenTelemetry Authors
@@ -73,11 +74,11 @@ public final class {{ root_namespace | to_camelcase(True) }}{{ classPrefix }}Att
         <ul> {{attribute.note | replace("> ", "") | render_markdown(code="{{@code {0}}}", paragraph="<li>{0}</li>", list="{0}")}} </ul>
 
     {%- endif %}
-    {%- if attribute | is_deprecated %}
   *
+    {%- if attribute | is_deprecated %}
   * @deprecated {{attribute.brief | to_doc_brief}}.
     {%- elif attribute | is_stable and stablePkg != "" %}
-  * @deprecated deprecated in favor of stable {@link {{stable_class_ref(attribute_const_name)}}} attribute.
+  * @deprecated deprecated in favor of stable {@link {{stable_class_ref(attribute_const_name, '#')}}} attribute.
     {%- endif %}
   */
     {%- if attribute | is_deprecated or attribute | is_stable and stablePkg != "" %}
@@ -90,14 +91,28 @@ public final class {{ root_namespace | to_camelcase(True) }}{{ classPrefix }}Att
     {%- endif %}
   {%- endfor %}
 
+  {%- if filtered_enums | count > 0  %}
   // Enum definitions
-  {%- for attribute in filtered_attributes if attribute.is_enum %}
-  {%- set class_name = attribute.fqn | to_camelcase(True) ~ "Values" %}
-  {%- set type = to_java_return_type(attribute.attr_type.enum_type) %}
+  {%- endif %}
+  {%- for enum_attribute in filtered_enums %}
+  {%- set class_name = enum_attribute.fqn | to_camelcase(True) ~ "Values" %}
+  {%- set type = to_java_return_type(enum_attribute.attr_type.enum_type) %}
+  /**
+  * Values for {@link #{{ enum_attribute.fqn | to_const_name }}}.
+  *
+    {%- if enum_attribute | is_deprecated %}
+  * @deprecated {{enum_attribute.brief | to_doc_brief}}.
+    {%- elif enum_attribute | is_stable and stablePkg != "" %}
+  * @deprecated deprecated in favor of stable {@link {{stable_class_ref(class_name, '.')}}} attribute.
+    {%- endif %}
+  */
+    {%- if enum_attribute | is_deprecated or enum_attribute | is_stable and stablePkg != "" %}
+  @Deprecated
+    {%- endif %}
   public static final class {{class_name}} {
-    {%- for member in attribute.attr_type.members %}
+    {%- for member in enum_attribute.attr_type.members %}
       /** {% filter escape %}{{member.brief | to_doc_brief}}.{% endfilter %} */
-      public static final {{ type }} {{ member.member_id | to_const_name }} = {{ attribute | print_member_value(member) }};
+      public static final {{ type }} {{ member.member_id | to_const_name }} = {{ enum_attribute | print_member_value(member) }};
 
     {%- endfor %}
 

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/AndroidIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/AndroidIncubatingAttributes.java
@@ -36,6 +36,7 @@ public final class AndroidIncubatingAttributes {
   public static final AttributeKey<String> ANDROID_STATE = stringKey("android.state");
 
   // Enum definitions
+  /** Values for {@link #ANDROID_STATE}. */
   public static final class AndroidStateValues {
     /**
      * Any time before Activity.onResume() or, if the app has no Activity, Context.startService()

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/AwsIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/AwsIncubatingAttributes.java
@@ -344,6 +344,7 @@ public final class AwsIncubatingAttributes {
   public static final AttributeKey<String> AWS_S3_UPLOAD_ID = stringKey("aws.s3.upload_id");
 
   // Enum definitions
+  /** Values for {@link #AWS_ECS_LAUNCHTYPE}. */
   public static final class AwsEcsLaunchtypeValues {
     /** ec2. */
     public static final String EC2 = "ec2";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/BrowserIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/BrowserIncubatingAttributes.java
@@ -74,7 +74,5 @@ public final class BrowserIncubatingAttributes {
    */
   public static final AttributeKey<String> BROWSER_PLATFORM = stringKey("browser.platform");
 
-  // Enum definitions
-
   private BrowserIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ClientIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ClientIncubatingAttributes.java
@@ -48,7 +48,5 @@ public final class ClientIncubatingAttributes {
    */
   @Deprecated public static final AttributeKey<Long> CLIENT_PORT = longKey("client.port");
 
-  // Enum definitions
-
   private ClientIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/CloudIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/CloudIncubatingAttributes.java
@@ -96,6 +96,7 @@ public final class CloudIncubatingAttributes {
   public static final AttributeKey<String> CLOUD_RESOURCE_ID = stringKey("cloud.resource_id");
 
   // Enum definitions
+  /** Values for {@link #CLOUD_PLATFORM}. */
   public static final class CloudPlatformValues {
     /** Alibaba Cloud Elastic Compute Service. */
     public static final String ALIBABA_CLOUD_ECS = "alibaba_cloud_ecs";
@@ -181,6 +182,7 @@ public final class CloudIncubatingAttributes {
     private CloudPlatformValues() {}
   }
 
+  /** Values for {@link #CLOUD_PROVIDER}. */
   public static final class CloudProviderValues {
     /** Alibaba Cloud. */
     public static final String ALIBABA_CLOUD = "alibaba_cloud";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/CloudeventsIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/CloudeventsIncubatingAttributes.java
@@ -53,7 +53,5 @@ public final class CloudeventsIncubatingAttributes {
   public static final AttributeKey<String> CLOUDEVENTS_EVENT_TYPE =
       stringKey("cloudevents.event_type");
 
-  // Enum definitions
-
   private CloudeventsIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/CodeIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/CodeIncubatingAttributes.java
@@ -45,7 +45,5 @@ public final class CodeIncubatingAttributes {
    */
   public static final AttributeKey<String> CODE_NAMESPACE = stringKey("code.namespace");
 
-  // Enum definitions
-
   private CodeIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ContainerIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ContainerIncubatingAttributes.java
@@ -104,7 +104,5 @@ public final class ContainerIncubatingAttributes {
   /** The container runtime managing this container. */
   public static final AttributeKey<String> CONTAINER_RUNTIME = stringKey("container.runtime");
 
-  // Enum definitions
-
   private ContainerIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/DbIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/DbIncubatingAttributes.java
@@ -222,6 +222,7 @@ public final class DbIncubatingAttributes {
   public static final AttributeKey<String> DB_USER = stringKey("db.user");
 
   // Enum definitions
+  /** Values for {@link #DB_CASSANDRA_CONSISTENCY_LEVEL}. */
   public static final class DbCassandraConsistencyLevelValues {
     /** all. */
     public static final String ALL = "all";
@@ -259,6 +260,7 @@ public final class DbIncubatingAttributes {
     private DbCassandraConsistencyLevelValues() {}
   }
 
+  /** Values for {@link #DB_COSMOSDB_CONNECTION_MODE}. */
   public static final class DbCosmosdbConnectionModeValues {
     /** Gateway (HTTP) connections mode. */
     public static final String GATEWAY = "gateway";
@@ -269,6 +271,7 @@ public final class DbIncubatingAttributes {
     private DbCosmosdbConnectionModeValues() {}
   }
 
+  /** Values for {@link #DB_COSMOSDB_OPERATION_TYPE}. */
   public static final class DbCosmosdbOperationTypeValues {
     /** invalid. */
     public static final String INVALID = "Invalid";
@@ -318,6 +321,7 @@ public final class DbIncubatingAttributes {
     private DbCosmosdbOperationTypeValues() {}
   }
 
+  /** Values for {@link #DB_SYSTEM}. */
   public static final class DbSystemValues {
     /** Some other SQL database. Fallback only. See notes. */
     public static final String OTHER_SQL = "other_sql";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/DeploymentIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/DeploymentIncubatingAttributes.java
@@ -21,7 +21,5 @@ public final class DeploymentIncubatingAttributes {
   public static final AttributeKey<String> DEPLOYMENT_ENVIRONMENT =
       stringKey("deployment.environment");
 
-  // Enum definitions
-
   private DeploymentIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/DestinationIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/DestinationIncubatingAttributes.java
@@ -32,7 +32,5 @@ public final class DestinationIncubatingAttributes {
   /** Destination port number */
   public static final AttributeKey<Long> DESTINATION_PORT = longKey("destination.port");
 
-  // Enum definitions
-
   private DestinationIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/DeviceIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/DeviceIncubatingAttributes.java
@@ -73,7 +73,5 @@ public final class DeviceIncubatingAttributes {
    */
   public static final AttributeKey<String> DEVICE_MODEL_NAME = stringKey("device.model.name");
 
-  // Enum definitions
-
   private DeviceIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/EnduserIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/EnduserIncubatingAttributes.java
@@ -37,7 +37,5 @@ public final class EnduserIncubatingAttributes {
    */
   public static final AttributeKey<String> ENDUSER_SCOPE = stringKey("enduser.scope");
 
-  // Enum definitions
-
   private EnduserIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ErrorIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ErrorIncubatingAttributes.java
@@ -41,6 +41,13 @@ public final class ErrorIncubatingAttributes {
   @Deprecated public static final AttributeKey<String> ERROR_TYPE = stringKey("error.type");
 
   // Enum definitions
+  /**
+   * Values for {@link #ERROR_TYPE}.
+   *
+   * @deprecated deprecated in favor of stable {@link
+   *     io.opentelemetry.semconv.ErrorAttributes.ErrorTypeValues} attribute.
+   */
+  @Deprecated
   public static final class ErrorTypeValues {
     /**
      * A fallback error value to be used when the instrumentation doesn&#39;t define a custom value.

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/EventIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/EventIncubatingAttributes.java
@@ -30,6 +30,7 @@ public final class EventIncubatingAttributes {
   public static final AttributeKey<String> EVENT_NAME = stringKey("event.name");
 
   // Enum definitions
+  /** Values for {@link #EVENT_DOMAIN}. */
   public static final class EventDomainValues {
     /** Events from browser apps. */
     public static final String BROWSER = "browser";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ExceptionIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ExceptionIncubatingAttributes.java
@@ -53,7 +53,5 @@ public final class ExceptionIncubatingAttributes {
    */
   public static final AttributeKey<String> EXCEPTION_TYPE = stringKey("exception.type");
 
-  // Enum definitions
-
   private ExceptionIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/FaasIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/FaasIncubatingAttributes.java
@@ -170,6 +170,7 @@ public final class FaasIncubatingAttributes {
   public static final AttributeKey<String> FAAS_VERSION = stringKey("faas.version");
 
   // Enum definitions
+  /** Values for {@link #FAAS_DOCUMENT_OPERATION}. */
   public static final class FaasDocumentOperationValues {
     /** When a new object is created. */
     public static final String INSERT = "insert";
@@ -183,6 +184,7 @@ public final class FaasIncubatingAttributes {
     private FaasDocumentOperationValues() {}
   }
 
+  /** Values for {@link #FAAS_INVOKED_PROVIDER}. */
   public static final class FaasInvokedProviderValues {
     /** Alibaba Cloud. */
     public static final String ALIBABA_CLOUD = "alibaba_cloud";
@@ -202,6 +204,7 @@ public final class FaasIncubatingAttributes {
     private FaasInvokedProviderValues() {}
   }
 
+  /** Values for {@link #FAAS_TRIGGER}. */
   public static final class FaasTriggerValues {
     /** A response to some data source operation such as a database or filesystem read/write. */
     public static final String DATASOURCE = "datasource";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/FeatureFlagIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/FeatureFlagIncubatingAttributes.java
@@ -39,7 +39,5 @@ public final class FeatureFlagIncubatingAttributes {
    */
   public static final AttributeKey<String> FEATURE_FLAG_VARIANT = stringKey("feature_flag.variant");
 
-  // Enum definitions
-
   private FeatureFlagIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/GcpIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/GcpIncubatingAttributes.java
@@ -50,7 +50,5 @@ public final class GcpIncubatingAttributes {
   public static final AttributeKey<String> GCP_GCE_INSTANCE_NAME =
       stringKey("gcp.gce.instance.name");
 
-  // Enum definitions
-
   private GcpIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/GraphqlIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/GraphqlIncubatingAttributes.java
@@ -34,6 +34,7 @@ public final class GraphqlIncubatingAttributes {
       stringKey("graphql.operation.type");
 
   // Enum definitions
+  /** Values for {@link #GRAPHQL_OPERATION_TYPE}. */
   public static final class GraphqlOperationTypeValues {
     /** GraphQL query. */
     public static final String QUERY = "query";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/HerokuIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/HerokuIncubatingAttributes.java
@@ -25,7 +25,5 @@ public final class HerokuIncubatingAttributes {
   public static final AttributeKey<String> HEROKU_RELEASE_CREATION_TIMESTAMP =
       stringKey("heroku.release.creation_timestamp");
 
-  // Enum definitions
-
   private HerokuIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/HostIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/HostIncubatingAttributes.java
@@ -107,6 +107,7 @@ public final class HostIncubatingAttributes {
   public static final AttributeKey<String> HOST_TYPE = stringKey("host.type");
 
   // Enum definitions
+  /** Values for {@link #HOST_ARCH}. */
   public static final class HostArchValues {
     /** AMD64. */
     public static final String AMD64 = "amd64";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/HttpIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/HttpIncubatingAttributes.java
@@ -193,6 +193,13 @@ public final class HttpIncubatingAttributes {
   public static final AttributeKey<String> HTTP_URL = stringKey("http.url");
 
   // Enum definitions
+  /**
+   * Values for {@link #HTTP_REQUEST_METHOD}.
+   *
+   * @deprecated deprecated in favor of stable {@link
+   *     io.opentelemetry.semconv.HttpAttributes.HttpRequestMethodValues} attribute.
+   */
+  @Deprecated
   public static final class HttpRequestMethodValues {
     /** CONNECT method. */
     public static final String CONNECT = "CONNECT";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/IosIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/IosIncubatingAttributes.java
@@ -29,6 +29,7 @@ public final class IosIncubatingAttributes {
   public static final AttributeKey<String> IOS_STATE = stringKey("ios.state");
 
   // Enum definitions
+  /** Values for {@link #IOS_STATE}. */
   public static final class IosStateValues {
     /**
      * The app has become `active`. Associated with UIKit notification `applicationDidBecomeActive`.

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/JvmIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/JvmIncubatingAttributes.java
@@ -73,6 +73,7 @@ public final class JvmIncubatingAttributes {
   public static final AttributeKey<String> JVM_THREAD_STATE = stringKey("jvm.thread.state");
 
   // Enum definitions
+  /** Values for {@link #JVM_MEMORY_TYPE}. */
   public static final class JvmMemoryTypeValues {
     /** Heap memory. */
     public static final String HEAP = "heap";
@@ -83,6 +84,7 @@ public final class JvmIncubatingAttributes {
     private JvmMemoryTypeValues() {}
   }
 
+  /** Values for {@link #JVM_THREAD_STATE}. */
   public static final class JvmThreadStateValues {
     /** A thread that has not yet started is in this state. */
     public static final String NEW = "new";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/K8sIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/K8sIncubatingAttributes.java
@@ -107,7 +107,5 @@ public final class K8sIncubatingAttributes {
   /** The UID of the StatefulSet. */
   public static final AttributeKey<String> K8S_STATEFULSET_UID = stringKey("k8s.statefulset.uid");
 
-  // Enum definitions
-
   private K8sIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/LogIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/LogIncubatingAttributes.java
@@ -47,6 +47,7 @@ public final class LogIncubatingAttributes {
   public static final AttributeKey<String> LOG_RECORD_UID = stringKey("log.record.uid");
 
   // Enum definitions
+  /** Values for {@link #LOG_IOSTREAM}. */
   public static final class LogIostreamValues {
     /** Logs from stdout stream. */
     public static final String STDOUT = "stdout";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/MessageIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/MessageIncubatingAttributes.java
@@ -40,6 +40,7 @@ public final class MessageIncubatingAttributes {
       longKey("message.uncompressed_size");
 
   // Enum definitions
+  /** Values for {@link #MESSAGE_TYPE}. */
   public static final class MessageTypeValues {
     /** sent. */
     public static final String SENT = "SENT";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/MessagingIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/MessagingIncubatingAttributes.java
@@ -236,6 +236,7 @@ public final class MessagingIncubatingAttributes {
   public static final AttributeKey<String> MESSAGING_SYSTEM = stringKey("messaging.system");
 
   // Enum definitions
+  /** Values for {@link #MESSAGING_OPERATION}. */
   public static final class MessagingOperationValues {
     /**
      * One or more messages are provided for publishing to an intermediary. If a single message is
@@ -265,6 +266,7 @@ public final class MessagingIncubatingAttributes {
     private MessagingOperationValues() {}
   }
 
+  /** Values for {@link #MESSAGING_ROCKETMQ_CONSUMPTION_MODEL}. */
   public static final class MessagingRocketmqConsumptionModelValues {
     /** Clustering consumption model. */
     public static final String CLUSTERING = "clustering";
@@ -275,6 +277,7 @@ public final class MessagingIncubatingAttributes {
     private MessagingRocketmqConsumptionModelValues() {}
   }
 
+  /** Values for {@link #MESSAGING_ROCKETMQ_MESSAGE_TYPE}. */
   public static final class MessagingRocketmqMessageTypeValues {
     /** Normal message. */
     public static final String NORMAL = "normal";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/NetIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/NetIncubatingAttributes.java
@@ -60,6 +60,7 @@ public final class NetIncubatingAttributes {
   public static final AttributeKey<String> NET_TRANSPORT = stringKey("net.transport");
 
   // Enum definitions
+  /** Values for {@link #NET_SOCK_FAMILY}. */
   public static final class NetSockFamilyValues {
     /** IPv4 address. */
     public static final String INET = "inet";
@@ -73,6 +74,7 @@ public final class NetIncubatingAttributes {
     private NetSockFamilyValues() {}
   }
 
+  /** Values for {@link #NET_TRANSPORT}. */
   public static final class NetTransportValues {
     /** ip_tcp. */
     public static final String IP_TCP = "ip_tcp";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/NetworkIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/NetworkIncubatingAttributes.java
@@ -145,6 +145,7 @@ public final class NetworkIncubatingAttributes {
   @Deprecated public static final AttributeKey<String> NETWORK_TYPE = stringKey("network.type");
 
   // Enum definitions
+  /** Values for {@link #NETWORK_CONNECTION_SUBTYPE}. */
   public static final class NetworkConnectionSubtypeValues {
     /** GPRS. */
     public static final String GPRS = "gprs";
@@ -212,6 +213,7 @@ public final class NetworkIncubatingAttributes {
     private NetworkConnectionSubtypeValues() {}
   }
 
+  /** Values for {@link #NETWORK_CONNECTION_TYPE}. */
   public static final class NetworkConnectionTypeValues {
     /** wifi. */
     public static final String WIFI = "wifi";
@@ -231,6 +233,13 @@ public final class NetworkIncubatingAttributes {
     private NetworkConnectionTypeValues() {}
   }
 
+  /**
+   * Values for {@link #NETWORK_TRANSPORT}.
+   *
+   * @deprecated deprecated in favor of stable {@link
+   *     io.opentelemetry.semconv.NetworkAttributes.NetworkTransportValues} attribute.
+   */
+  @Deprecated
   public static final class NetworkTransportValues {
     /** TCP. */
     public static final String TCP = "tcp";
@@ -247,6 +256,13 @@ public final class NetworkIncubatingAttributes {
     private NetworkTransportValues() {}
   }
 
+  /**
+   * Values for {@link #NETWORK_TYPE}.
+   *
+   * @deprecated deprecated in favor of stable {@link
+   *     io.opentelemetry.semconv.NetworkAttributes.NetworkTypeValues} attribute.
+   */
+  @Deprecated
   public static final class NetworkTypeValues {
     /** IPv4. */
     public static final String IPV4 = "ipv4";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/OciIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/OciIncubatingAttributes.java
@@ -31,7 +31,5 @@ public final class OciIncubatingAttributes {
    */
   public static final AttributeKey<String> OCI_MANIFEST_DIGEST = stringKey("oci.manifest.digest");
 
-  // Enum definitions
-
   private OciIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/OpentracingIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/OpentracingIncubatingAttributes.java
@@ -26,6 +26,7 @@ public final class OpentracingIncubatingAttributes {
   public static final AttributeKey<String> OPENTRACING_REF_TYPE = stringKey("opentracing.ref_type");
 
   // Enum definitions
+  /** Values for {@link #OPENTRACING_REF_TYPE}. */
   public static final class OpentracingRefTypeValues {
     /** The parent Span depends on the child Span in some capacity. */
     public static final String CHILD_OF = "child_of";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/OsIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/OsIncubatingAttributes.java
@@ -36,6 +36,7 @@ public final class OsIncubatingAttributes {
   public static final AttributeKey<String> OS_VERSION = stringKey("os.version");
 
   // Enum definitions
+  /** Values for {@link #OS_TYPE}. */
   public static final class OsTypeValues {
     /** Microsoft Windows. */
     public static final String WINDOWS = "windows";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/OtelIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/OtelIncubatingAttributes.java
@@ -37,6 +37,7 @@ public final class OtelIncubatingAttributes {
       stringKey("otel.status_description");
 
   // Enum definitions
+  /** Values for {@link #OTEL_STATUS_CODE}. */
   public static final class OtelStatusCodeValues {
     /**
      * The operation has been validated by an Application developer or Operator to have completed

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/OtherIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/OtherIncubatingAttributes.java
@@ -18,6 +18,7 @@ public final class OtherIncubatingAttributes {
   public static final AttributeKey<String> STATE = stringKey("state");
 
   // Enum definitions
+  /** Values for {@link #STATE}. */
   public static final class StateValues {
     /** idle. */
     public static final String IDLE = "idle";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/PeerIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/PeerIncubatingAttributes.java
@@ -21,7 +21,5 @@ public final class PeerIncubatingAttributes {
    */
   public static final AttributeKey<String> PEER_SERVICE = stringKey("peer.service");
 
-  // Enum definitions
-
   private PeerIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/PoolIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/PoolIncubatingAttributes.java
@@ -22,7 +22,5 @@ public final class PoolIncubatingAttributes {
    */
   public static final AttributeKey<String> POOL_NAME = stringKey("pool.name");
 
-  // Enum definitions
-
   private PoolIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ProcessIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ProcessIncubatingAttributes.java
@@ -84,7 +84,5 @@ public final class ProcessIncubatingAttributes {
   public static final AttributeKey<String> PROCESS_RUNTIME_VERSION =
       stringKey("process.runtime.version");
 
-  // Enum definitions
-
   private ProcessIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/RpcIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/RpcIncubatingAttributes.java
@@ -146,6 +146,7 @@ public final class RpcIncubatingAttributes {
   public static final AttributeKey<String> RPC_SYSTEM = stringKey("rpc.system");
 
   // Enum definitions
+  /** Values for {@link #RPC_CONNECT_RPC_ERROR_CODE}. */
   public static final class RpcConnectRpcErrorCodeValues {
     /** cancelled. */
     public static final String CANCELLED = "cancelled";
@@ -198,6 +199,7 @@ public final class RpcIncubatingAttributes {
     private RpcConnectRpcErrorCodeValues() {}
   }
 
+  /** Values for {@link #RPC_GRPC_STATUS_CODE}. */
   public static final class RpcGrpcStatusCodeValues {
     /** OK. */
     public static final long OK = 0;
@@ -253,6 +255,7 @@ public final class RpcIncubatingAttributes {
     private RpcGrpcStatusCodeValues() {}
   }
 
+  /** Values for {@link #RPC_SYSTEM}. */
   public static final class RpcSystemValues {
     /** gRPC. */
     public static final String GRPC = "grpc";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ServerIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ServerIncubatingAttributes.java
@@ -48,7 +48,5 @@ public final class ServerIncubatingAttributes {
    */
   @Deprecated public static final AttributeKey<Long> SERVER_PORT = longKey("server.port");
 
-  // Enum definitions
-
   private ServerIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ServiceIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ServiceIncubatingAttributes.java
@@ -71,7 +71,5 @@ public final class ServiceIncubatingAttributes {
    */
   public static final AttributeKey<String> SERVICE_VERSION = stringKey("service.version");
 
-  // Enum definitions
-
   private ServiceIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/SessionIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/SessionIncubatingAttributes.java
@@ -20,7 +20,5 @@ public final class SessionIncubatingAttributes {
   /** The previous {@code session.id} for this user, when known. */
   public static final AttributeKey<String> SESSION_PREVIOUS_ID = stringKey("session.previous_id");
 
-  // Enum definitions
-
   private SessionIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/SourceIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/SourceIncubatingAttributes.java
@@ -32,7 +32,5 @@ public final class SourceIncubatingAttributes {
   /** Source port number */
   public static final AttributeKey<Long> SOURCE_PORT = longKey("source.port");
 
-  // Enum definitions
-
   private SourceIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/SystemIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/SystemIncubatingAttributes.java
@@ -74,6 +74,7 @@ public final class SystemIncubatingAttributes {
       stringKey("system.processes.status");
 
   // Enum definitions
+  /** Values for {@link #SYSTEM_CPU_STATE}. */
   public static final class SystemCpuStateValues {
     /** user. */
     public static final String USER = "user";
@@ -99,6 +100,7 @@ public final class SystemIncubatingAttributes {
     private SystemCpuStateValues() {}
   }
 
+  /** Values for {@link #SYSTEM_DISK_DIRECTION}. */
   public static final class SystemDiskDirectionValues {
     /** read. */
     public static final String READ = "read";
@@ -109,6 +111,7 @@ public final class SystemIncubatingAttributes {
     private SystemDiskDirectionValues() {}
   }
 
+  /** Values for {@link #SYSTEM_FILESYSTEM_STATE}. */
   public static final class SystemFilesystemStateValues {
     /** used. */
     public static final String USED = "used";
@@ -122,6 +125,7 @@ public final class SystemIncubatingAttributes {
     private SystemFilesystemStateValues() {}
   }
 
+  /** Values for {@link #SYSTEM_FILESYSTEM_TYPE}. */
   public static final class SystemFilesystemTypeValues {
     /** fat32. */
     public static final String FAT32 = "fat32";
@@ -144,6 +148,7 @@ public final class SystemIncubatingAttributes {
     private SystemFilesystemTypeValues() {}
   }
 
+  /** Values for {@link #SYSTEM_MEMORY_STATE}. */
   public static final class SystemMemoryStateValues {
     /** used. */
     public static final String USED = "used";
@@ -163,6 +168,7 @@ public final class SystemIncubatingAttributes {
     private SystemMemoryStateValues() {}
   }
 
+  /** Values for {@link #SYSTEM_NETWORK_DIRECTION}. */
   public static final class SystemNetworkDirectionValues {
     /** transmit. */
     public static final String TRANSMIT = "transmit";
@@ -173,6 +179,7 @@ public final class SystemIncubatingAttributes {
     private SystemNetworkDirectionValues() {}
   }
 
+  /** Values for {@link #SYSTEM_NETWORK_STATE}. */
   public static final class SystemNetworkStateValues {
     /** close. */
     public static final String CLOSE = "close";
@@ -213,6 +220,7 @@ public final class SystemIncubatingAttributes {
     private SystemNetworkStateValues() {}
   }
 
+  /** Values for {@link #SYSTEM_PAGING_DIRECTION}. */
   public static final class SystemPagingDirectionValues {
     /** in. */
     public static final String IN = "in";
@@ -223,6 +231,7 @@ public final class SystemIncubatingAttributes {
     private SystemPagingDirectionValues() {}
   }
 
+  /** Values for {@link #SYSTEM_PAGING_STATE}. */
   public static final class SystemPagingStateValues {
     /** used. */
     public static final String USED = "used";
@@ -233,6 +242,7 @@ public final class SystemIncubatingAttributes {
     private SystemPagingStateValues() {}
   }
 
+  /** Values for {@link #SYSTEM_PAGING_TYPE}. */
   public static final class SystemPagingTypeValues {
     /** major. */
     public static final String MAJOR = "major";
@@ -243,6 +253,7 @@ public final class SystemIncubatingAttributes {
     private SystemPagingTypeValues() {}
   }
 
+  /** Values for {@link #SYSTEM_PROCESSES_STATUS}. */
   public static final class SystemProcessesStatusValues {
     /** running. */
     public static final String RUNNING = "running";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/TelemetryIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/TelemetryIncubatingAttributes.java
@@ -58,6 +58,7 @@ public final class TelemetryIncubatingAttributes {
       stringKey("telemetry.sdk.version");
 
   // Enum definitions
+  /** Values for {@link #TELEMETRY_SDK_LANGUAGE}. */
   public static final class TelemetrySdkLanguageValues {
     /** cpp. */
     public static final String CPP = "cpp";

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ThreadIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/ThreadIncubatingAttributes.java
@@ -21,7 +21,5 @@ public final class ThreadIncubatingAttributes {
   /** Current thread name. */
   public static final AttributeKey<String> THREAD_NAME = stringKey("thread.name");
 
-  // Enum definitions
-
   private ThreadIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/UrlIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/UrlIncubatingAttributes.java
@@ -76,7 +76,5 @@ public final class UrlIncubatingAttributes {
    */
   @Deprecated public static final AttributeKey<String> URL_SCHEME = stringKey("url.scheme");
 
-  // Enum definitions
-
   private UrlIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/UserAgentIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/UserAgentIncubatingAttributes.java
@@ -24,7 +24,5 @@ public final class UserAgentIncubatingAttributes {
   @Deprecated
   public static final AttributeKey<String> USER_AGENT_ORIGINAL = stringKey("user_agent.original");
 
-  // Enum definitions
-
   private UserAgentIncubatingAttributes() {}
 }

--- a/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/WebengineIncubatingAttributes.java
+++ b/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/WebengineIncubatingAttributes.java
@@ -24,7 +24,5 @@ public final class WebengineIncubatingAttributes {
   /** The version of the web engine. */
   public static final AttributeKey<String> WEBENGINE_VERSION = stringKey("webengine.version");
 
-  // Enum definitions
-
   private WebengineIncubatingAttributes() {}
 }

--- a/semconv/src/main/java/io/opentelemetry/semconv/ClientAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/ClientAttributes.java
@@ -42,7 +42,5 @@ public final class ClientAttributes {
    */
   public static final AttributeKey<Long> CLIENT_PORT = longKey("client.port");
 
-  // Enum definitions
-
   private ClientAttributes() {}
 }

--- a/semconv/src/main/java/io/opentelemetry/semconv/ErrorAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/ErrorAttributes.java
@@ -38,6 +38,7 @@ public final class ErrorAttributes {
   public static final AttributeKey<String> ERROR_TYPE = stringKey("error.type");
 
   // Enum definitions
+  /** Values for {@link #ERROR_TYPE}. */
   public static final class ErrorTypeValues {
     /**
      * A fallback error value to be used when the instrumentation doesn&#39;t define a custom value.

--- a/semconv/src/main/java/io/opentelemetry/semconv/HttpAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/HttpAttributes.java
@@ -121,6 +121,7 @@ public final class HttpAttributes {
   public static final AttributeKey<String> HTTP_ROUTE = stringKey("http.route");
 
   // Enum definitions
+  /** Values for {@link #HTTP_REQUEST_METHOD}. */
   public static final class HttpRequestMethodValues {
     /** CONNECT method. */
     public static final String CONNECT = "CONNECT";

--- a/semconv/src/main/java/io/opentelemetry/semconv/NetworkAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/NetworkAttributes.java
@@ -83,6 +83,7 @@ public final class NetworkAttributes {
   public static final AttributeKey<String> NETWORK_TYPE = stringKey("network.type");
 
   // Enum definitions
+  /** Values for {@link #NETWORK_TRANSPORT}. */
   public static final class NetworkTransportValues {
     /** TCP. */
     public static final String TCP = "tcp";
@@ -99,6 +100,7 @@ public final class NetworkAttributes {
     private NetworkTransportValues() {}
   }
 
+  /** Values for {@link #NETWORK_TYPE}. */
   public static final class NetworkTypeValues {
     /** IPv4. */
     public static final String IPV4 = "ipv4";

--- a/semconv/src/main/java/io/opentelemetry/semconv/ServerAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/ServerAttributes.java
@@ -42,7 +42,5 @@ public final class ServerAttributes {
    */
   public static final AttributeKey<Long> SERVER_PORT = longKey("server.port");
 
-  // Enum definitions
-
   private ServerAttributes() {}
 }

--- a/semconv/src/main/java/io/opentelemetry/semconv/UrlAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/UrlAttributes.java
@@ -57,7 +57,5 @@ public final class UrlAttributes {
    */
   public static final AttributeKey<String> URL_SCHEME = stringKey("url.scheme");
 
-  // Enum definitions
-
   private UrlAttributes() {}
 }

--- a/semconv/src/main/java/io/opentelemetry/semconv/UserAgentAttributes.java
+++ b/semconv/src/main/java/io/opentelemetry/semconv/UserAgentAttributes.java
@@ -20,7 +20,5 @@ public final class UserAgentAttributes {
    */
   public static final AttributeKey<String> USER_AGENT_ORIGINAL = stringKey("user_agent.original");
 
-  // Enum definitions
-
   private UserAgentAttributes() {}
 }


### PR DESCRIPTION
Resolves #49.

- Adds enum javadoc pointing back to corresponding attribute constant
- Add deprecated javadoc / annotation based on same rules as attributes
- Exclude the `// Enum definitions` comment if a namespace doesn't have any enums