### PR TITLE
Remove unnecessary javadoc config

### DIFF
--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -77,8 +77,6 @@ tasks {
       breakIterator(true)
 
       addBooleanOption("html5", true)
-
-      links("https://docs.oracle.com/javase/8/docs/api/")
       addBooleanOption("Xdoclint:all,-missing", true)
     }
   }


### PR DESCRIPTION
Not sure why this was needed, but tried without it and javadoc links seems to be fine