### PR TITLE
Fail of javadoc warnings

### DIFF
--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -79,6 +79,8 @@ tasks {
       // TODO (trask) need to disable html validation until next semconv release
       //  see https://github.com/open-telemetry/semantic-conventions/pull/1664
       addBooleanOption("Xdoclint:all,-missing,-html", true)
+      // non-standard option to fail on warnings, see https://bugs.openjdk.java.net/browse/JDK-8200363
+      addStringOption("Xwerror", "-quiet")
     }
   }
 


### PR DESCRIPTION
Currently fails with

```
/home/runner/work/semantic-conventions-java/semantic-conventions-java/semconv/src/main/java/io/opentelemetry/semconv/ErrorAttributes.java:39: warning: empty <p> tag
   * <p>
     ^
error: warnings found and -Werror specified
1 error
2 warnings
```

due to this empty `<p>`:

https://github.com/open-telemetry/semantic-conventions-java/blob/d3aa5f6f7c5822554fbf93c534d159c15ff545c8/semconv/src/main/java/io/opentelemetry/semconv/ErrorAttributes.java#L38-L40

I checked the rendering and it looks like we can just remove that `<p>` and things render the same.