### PR TITLE
Add java-instrumentation-approvers as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
  # For anything not explicitly taken by someone else:
-* @open-telemetry/java-approvers
+* @open-telemetry/java-approvers @open-telemetry/java-instrumentation-approvers


### PR DESCRIPTION
Resolves #104.

TODO: grant @open-telemetry/java-instrumentation-maintainers "maintain" role upon merging.

Looking for approvals from @open-telemetry/java-approvers and @open-telemetry/java-instrumentation-approvers on this one.