### PR TITLE
Pin io.opentelemetry dependencies to 1.33.0

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "packageRules": [
+    {
+      // pin io.opentelemetry dependencies to avoid churn and for conservative api version requirement
+      "matchPackagePrefixes": ["io.opentelemetry:"],
+      "matchCurrentVersion": "1.33.0",
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
See https://github.com/open-telemetry/semantic-conventions-java/pull/109#pullrequestreview-2486095128

Pinning the `io.opentelemetry:opentelemetry-api` version has two purposes:

- Reduce churn
- Have conservative API requirements since this repo doesn't use anything from the later versions (as of now)