### PR TITLE
Fix gradle warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,7 +79,7 @@ val unzipConfigurationSchema by tasks.registering(Copy::class) {
     val pathParts = path.split("/")
     path = pathParts.subList(1, pathParts.size).joinToString("/")
   })
-  into(layout.buildDirectory.file("semantic-conventions-${semanticConventionsVersion}/"))
+  into(layout.buildDirectory.dir("semantic-conventions-${semanticConventionsVersion}/"))
 }
 
 fun generateTask(taskName: String, incubating: Boolean) {
@@ -102,7 +102,7 @@ fun generateTask(taskName: String, incubating: Boolean) {
       val gid = unix.getGid() // $(id -g $USERNAME)
       listOf("-u", "$uid:$gid")
     }
-    val modelPath = layout.buildDirectory.file("semantic-conventions-${semanticConventionsVersion}/model").get()
+    val modelPath = layout.buildDirectory.dir("semantic-conventions-${semanticConventionsVersion}/model").get()
     val weaver_args = listOf(
         "--rm",
         "--platform=linux/x86_64",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,7 @@ val schemaUrl = "https://opentelemetry.io/schemas/$semanticConventionsVersion"
 
 val downloadSemanticConventions by tasks.registering(Download::class) {
   src(semanticConventionsRepoZip)
-  dest("$buildDir/semantic-conventions-${semanticConventionsVersion}/semantic-conventions.zip")
+  dest("${layout.buildDirectory.asFile.get()}/semantic-conventions-${semanticConventionsVersion}/semantic-conventions.zip")
   overwrite(false)
 }
 
@@ -79,7 +79,7 @@ val unzipConfigurationSchema by tasks.registering(Copy::class) {
     val pathParts = path.split("/")
     path = pathParts.subList(1, pathParts.size).joinToString("/")
   })
-  into("$buildDir/semantic-conventions-${semanticConventionsVersion}/")
+  into("${layout.buildDirectory.asFile.get()}/semantic-conventions-${semanticConventionsVersion}/")
 }
 
 fun generateTask(taskName: String, incubating: Boolean) {
@@ -105,7 +105,7 @@ fun generateTask(taskName: String, incubating: Boolean) {
     val weaver_args = listOf(
         "--rm",
         "--platform=linux/x86_64",
-        "--mount", "type=bind,source=$buildDir/semantic-conventions-${semanticConventionsVersion}/model,target=/home/weaver/source,readonly",
+        "--mount", "type=bind,source=${layout.buildDirectory.asFile.get()}/semantic-conventions-${semanticConventionsVersion}/model,target=/home/weaver/source,readonly",
         "--mount", "type=bind,source=$projectDir/buildscripts/templates,target=/home/weaver/templates,readonly",
         "--mount", "type=bind,source=$projectDir/$outputDir,target=/home/weaver/target",
         "otel/weaver:$generatorVersion",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,7 @@ val schemaUrl = "https://opentelemetry.io/schemas/$semanticConventionsVersion"
 
 val downloadSemanticConventions by tasks.registering(Download::class) {
   src(semanticConventionsRepoZip)
-  dest("${layout.buildDirectory.asFile.get()}/semantic-conventions-${semanticConventionsVersion}/semantic-conventions.zip")
+  dest(layout.buildDirectory.file("semantic-conventions-${semanticConventionsVersion}/semantic-conventions.zip"))
   overwrite(false)
 }
 
@@ -79,7 +79,7 @@ val unzipConfigurationSchema by tasks.registering(Copy::class) {
     val pathParts = path.split("/")
     path = pathParts.subList(1, pathParts.size).joinToString("/")
   })
-  into("${layout.buildDirectory.asFile.get()}/semantic-conventions-${semanticConventionsVersion}/")
+  into(layout.buildDirectory.file("semantic-conventions-${semanticConventionsVersion}/"))
 }
 
 fun generateTask(taskName: String, incubating: Boolean) {
@@ -102,10 +102,11 @@ fun generateTask(taskName: String, incubating: Boolean) {
       val gid = unix.getGid() // $(id -g $USERNAME)
       listOf("-u", "$uid:$gid")
     }
+    val modelPath = layout.buildDirectory.file("semantic-conventions-${semanticConventionsVersion}/model").get()
     val weaver_args = listOf(
         "--rm",
         "--platform=linux/x86_64",
-        "--mount", "type=bind,source=${layout.buildDirectory.asFile.get()}/semantic-conventions-${semanticConventionsVersion}/model,target=/home/weaver/source,readonly",
+        "--mount", "type=bind,source=${modelPath},target=/home/weaver/source,readonly",
         "--mount", "type=bind,source=$projectDir/buildscripts/templates,target=/home/weaver/templates,readonly",
         "--mount", "type=bind,source=$projectDir/$outputDir,target=/home/weaver/target",
         "otel/weaver:$generatorVersion",

--- a/buildSrc/src/main/kotlin/otel.spotless-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.spotless-conventions.gradle.kts
@@ -70,7 +70,7 @@ spotless {
       "*.sh",
       "src/**/*.properties",
     )
-    indentWithSpaces()
+    leadingTabsToSpaces()
     trimTrailingWhitespace()
     endWithNewline()
   }


### PR DESCRIPTION
Fixes: 
```
w: file:///Users/jberg/code/open-telemetry/semantic-conventions-java/build.gradle.kts:69:10: 'getter for buildDir: File!' is deprecated. Deprecated in Java
w: file:///Users/jberg/code/open-telemetry/semantic-conventions-java/build.gradle.kts:82:10: 'getter for buildDir: File!' is deprecated. Deprecated in Java
w: file:///Users/jberg/code/open-telemetry/semantic-conventions-java/build.gradle.kts:108:39: 'getter for buildDir: File!' is deprecated. Deprecated in Java
'indentWithSpaces' is deprecated, use 'leadingTabsToSpaces' in your gradle build script instead.
'indentWithSpaces' is deprecated, use 'leadingTabsToSpaces' in your gradle build script instead.

```