### PR TITLE
Run gradle wrapper check all the time

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,19 +1,16 @@
 name: Gradle wrapper validation
+
 on:
-  pull_request:
-    paths:
-      - '**/gradle/wrapper/**'
   push:
-    paths:
-      - '**/gradle/wrapper/**'
+  pull_request:
 
 permissions:
   contents: read
 
 jobs:
-  validation:
+  gradle-wrapper-validation:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3.5.0
+      - uses: gradle/actions/wrapper-validation@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0


### PR DESCRIPTION
This makes OSSF not complain about the binary gradle wrapper files