### PR TITLE
Specify FOSSA team

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -17,3 +17,4 @@ jobs:
       - uses: fossas/fossa-action@93a52ecf7c3ac7eb40f5de77fd69b1a19524de94 # v1.5.0
         with:
           api-key: ${{secrets.FOSSA_API_KEY}}
+          team: OpenTelemetry


### PR DESCRIPTION
This is needed now that we are in the CNCF FOSSA org.