### PR TITLE
Fix japicmp

### DIFF
--- a/.github/workflows/generate-post-release-pr.yml
+++ b/.github/workflows/generate-post-release-pr.yml
@@ -1,0 +1,73 @@
+name: Generate Post-Release PR
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prereqs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Verify prerequisites
+        run: |
+          if [[ $GITHUB_REF_NAME != main ]]; then
+            echo this workflow should only be run against main
+            exit 1
+          fi
+
+  create-pull-request-against-main:
+    permissions:
+      contents: write # for git push to PR branch
+    runs-on: ubuntu-latest
+    needs:
+      - prereqs
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - id: setup-java
+        name: Set up Java for build
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set environment variables
+        run: |
+          version=$(.github/scripts/get-version.sh)
+          echo "VERSION=$version" >> $GITHUB_ENV
+          prior_version=$(.github/scripts/get-prior-version.sh)
+          echo "PRIOR_VERSION=$prior_version" >> $GITHUB_ENV
+          if [[ $prior_version =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            major="${BASH_REMATCH[1]}"
+            minor="${BASH_REMATCH[2]}"
+            patch="${BASH_REMATCH[3]}"
+            
+            two_releases_ago="$major.$((minor - 1)).$patch"
+          else
+            echo "unexpected prior version: $prior_version"
+            exit 1
+          fi
+          echo "TWO_VERSIONS_AGO=$two_releases_ago" >> $GITHUB_ENV
+      - name: Use CLA approved github bot
+        run: .github/scripts/use-cla-approved-github-bot.sh
+
+      - name: Create pull request against main
+        env:
+          # not using secrets.GITHUB_TOKEN since pull requests from that token do not run workflows
+          GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+        run: |
+          ./gradlew japicmp -PapiBaseVersion=$TWO_VERSIONS_AGO -PapiNewVersion=$PRIOR_VERSION
+          ./gradlew --refresh-dependencies japicmp
+   
+          message="Post release for version $PRIOR_VERSION"
+          body="Post-release updates for version \`$PRIOR_VERSION\`."
+          branch="opentelemetrybot/post-release-for-${PRIOR_VERSION}"
+
+          git checkout -b $branch
+          git add docs/apidiffs
+          git commit -a -m "$message"
+          git push --set-upstream origin $branch
+          gh pr create --title "$message" \
+                       --body "$body" \
+                       --base main

--- a/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
@@ -73,17 +73,16 @@ if (!project.hasProperty("otel.release")) {
         // the japicmp "old" version is either the user-specified one, or the latest release.
         val apiBaseVersion: String? by project
         val baselineVersion = apiBaseVersion ?: latestReleasedVersion
-        // TODO: uncomment after first stable release
-        // oldClasspath.from(
-        //    try {
-        //      files(findArtifact(baselineVersion))
-        //    } catch (e: Exception) {
-        //      // if we can't find the baseline artifact, this is probably one that's never been published before,
-        //      // so publish the whole API. We do that by flipping this flag, and comparing the current against nothing.
-        //      onlyModified.set(false)
-        //      files()
-        //    },
-        // )
+         oldClasspath.from(
+            try {
+              files(findArtifact(baselineVersion))
+            } catch (e: Exception) {
+              // if we can't find the baseline artifact, this is probably one that's never been published before,
+              // so publish the whole API. We do that by flipping this flag, and comparing the current against nothing.
+              onlyModified.set(false)
+              files()
+            },
+         )
 
         // Reproduce defaults from https://github.com/melix/japicmp-gradle-plugin/blob/09f52739ef1fccda6b4310cf3f4b19dc97377024/src/main/java/me/champeau/gradle/japicmp/report/ViolationsGenerator.java#L130
         // with some changes.
@@ -110,9 +109,6 @@ if (!project.hasProperty("otel.release")) {
 
         // this is needed so that we only consider the current artifact, and not dependencies
         ignoreMissingClasses.set(true)
-        // TODO: remove exclusions after first stable release
-        classExcludes.add("io.opentelemetry.semconv.ResourceAttributes")
-        classExcludes.add("io.opentelemetry.semconv.SemanticAttributes")
         val baseVersionString = if (apiBaseVersion == null) "latest" else baselineVersion
         txtOutputFile.set(
             apiNewVersion?.let { file("$rootDir/docs/apidiffs/${apiNewVersion}_vs_$baselineVersion/${base.archivesName.get()}.txt") }

--- a/docs/apidiffs/1.30.0/opentelemetry-semconv.txt
+++ b/docs/apidiffs/1.30.0/opentelemetry-semconv.txt
@@ -1,4 +1,8 @@
+<<<<<<< Updated upstream:docs/apidiffs/current_vs_latest/opentelemetry-semconv.txt
 Comparing source compatibility of opentelemetry-semconv-1.32.0-SNAPSHOT.jar against 
+=======
+Comparing source compatibility of opentelemetry-semconv-1.30.0.jar against 
+>>>>>>> Stashed changes:docs/apidiffs/1.30.0/opentelemetry-semconv.txt
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.semconv.AttributeKeyTemplate  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	GENERIC TEMPLATES: +++ T:java.lang.Object

--- a/docs/apidiffs/1.30.0/opentelemetry-semconv.txt
+++ b/docs/apidiffs/1.30.0/opentelemetry-semconv.txt
@@ -1,8 +1,4 @@
-<<<<<<< Updated upstream:docs/apidiffs/current_vs_latest/opentelemetry-semconv.txt
-Comparing source compatibility of opentelemetry-semconv-1.32.0-SNAPSHOT.jar against 
-=======
-Comparing source compatibility of opentelemetry-semconv-1.30.0.jar against 
->>>>>>> Stashed changes:docs/apidiffs/1.30.0/opentelemetry-semconv.txt
+Comparing source compatibility of opentelemetry-semconv-1.30.0.jar against
 +++  NEW CLASS: PUBLIC(+) FINAL(+) io.opentelemetry.semconv.AttributeKeyTemplate  (not serializable)
 	+++  CLASS FILE FORMAT VERSION: 52.0 <- n.a.
 	GENERIC TEMPLATES: +++ T:java.lang.Object

--- a/docs/apidiffs/1.31.0_vs_1.30.0/opentelemetry-semconv.txt
+++ b/docs/apidiffs/1.31.0_vs_1.30.0/opentelemetry-semconv.txt
@@ -1,0 +1,4 @@
+Comparing source compatibility of opentelemetry-semconv-1.31.0.jar against opentelemetry-semconv-1.30.0.jar
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.semconv.SchemaUrls  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW FIELD: PUBLIC(+) STATIC(+) FINAL(+) java.lang.String V1_31_0

--- a/docs/apidiffs/1.32.0_vs_1.31.0/opentelemetry-semconv.txt
+++ b/docs/apidiffs/1.32.0_vs_1.31.0/opentelemetry-semconv.txt
@@ -1,0 +1,4 @@
+Comparing source compatibility of opentelemetry-semconv-1.32.0.jar against opentelemetry-semconv-1.31.0.jar
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.semconv.SchemaUrls  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW FIELD: PUBLIC(+) STATIC(+) FINAL(+) java.lang.String V1_32_0

--- a/docs/apidiffs/current_vs_latest/opentelemetry-semconv.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-semconv.txt
@@ -1,0 +1,2 @@
+Comparing source compatibility of opentelemetry-semconv-1.32.0-SNAPSHOT.jar against opentelemetry-semconv-1.32.0.jar
+No changes.


### PR DESCRIPTION
The build automation that allows japicmp to record the diff in the stable API from version to version was never setup after the first stable version (1.30.0).

This PR enables it, an retroactively creates the japicmp diff docs for:
- 1.30.0
- 1.31.0 vs 1.30.0
- 1.32.0 vs 1.31.0

It ports the [generate post release PR](https://github.com/open-telemetry/opentelemetry-java/blob/main/.github/workflows/generate-post-release-pr.yml) github action from opentelemetry-java.