### PR TITLE
Update apidiff baseline to released version 1.36.0

### DIFF
--- a/docs/apidiffs/1.36.0_vs_1.34.0/opentelemetry-semconv.txt
+++ b/docs/apidiffs/1.36.0_vs_1.34.0/opentelemetry-semconv.txt
@@ -1,0 +1,5 @@
+Comparing source compatibility of opentelemetry-semconv-1.36.0.jar against opentelemetry-semconv-1.34.0.jar
+***  MODIFIED CLASS: PUBLIC FINAL io.opentelemetry.semconv.SchemaUrls  (not serializable)
+	===  CLASS FILE FORMAT VERSION: 52.0 <- 52.0
+	+++  NEW FIELD: PUBLIC(+) STATIC(+) FINAL(+) java.lang.String V1_36_0
+	+++  NEW FIELD: PUBLIC(+) STATIC(+) FINAL(+) java.lang.String V1_35_0

--- a/docs/apidiffs/current_vs_latest/opentelemetry-semconv.txt
+++ b/docs/apidiffs/current_vs_latest/opentelemetry-semconv.txt
@@ -1,2 +1,2 @@
-Comparing source compatibility of opentelemetry-semconv-1.32.0-SNAPSHOT.jar against opentelemetry-semconv-1.32.0.jar
+Comparing source compatibility of opentelemetry-semconv-1.36.0-SNAPSHOT.jar against opentelemetry-semconv-1.36.0.jar
 No changes.


### PR DESCRIPTION
This failed in post-release workflow due to #285