### PR TITLE
Fix Renovate Java configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -58,6 +58,7 @@
         '(?<currentValue>\\d+) # renovate: datasource=java-version',
       ],
       depNameTemplate: 'java',
+      extractVersionTemplate: '^(?<version>\\d+)',
     },
   ],
 }


### PR DESCRIPTION
Currently Renovate is failing with

> DEBUG: Extracted .github/workflows/build.yml after autoreplace has fewer deps than expected. (branch="renovate/java-25.x")
WARN: Error updating branch: update failure (branch="renovate/java-25.x")

Copied the configuration from the core repo where it's working.