### PR TITLE
Address gradle toolchain deprecation warning

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,11 +3,13 @@ pluginManagement {
     id("de.undercouch.download") version "5.6.0"
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
     id("com.gradle.develocity") version "4.2.2"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
   }
 }
 
 plugins {
   id("com.gradle.develocity")
+  id("org.gradle.toolchains.foojay-resolver-convention")
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
Same as https://github.com/open-telemetry/opentelemetry-java-contrib/pull/2380