### PR TITLE
fix: only apply deprecated note when required

### DIFF
--- a/buildscripts/templates/registry/java/SemanticAttributes.java.j2
+++ b/buildscripts/templates/registry/java/SemanticAttributes.java.j2
@@ -42,6 +42,8 @@ public final class {{ my_class_name }} {
     {%- if attribute is stable -%}
       {%- if attribute is deprecated -%}
         {%- set deprecated_javadoc = "@deprecated " ~ attribute.deprecated.note -%}
+      {%- else -%}
+        {%- set deprecated_javadoc = "" -%}
       {%- endif -%}
       {{ [attribute.brief, concat_if("\n\nNotes:\n\n", attribute.note), deprecated_javadoc] | comment }}
       {%- if attribute is deprecated -%}


### PR DESCRIPTION
Currently if a single attribute in a group contains the `deprecated` flag, it will erroneously apply the `@Deprecated` annotations to _all_ or at least _some_ attributes, instead of only the one attribute that was marked deprecated.

This PR fixes this by setting the deprecated note to `""` for attributes that are not deprecated.