### PR TITLE
Sync Java worflows: Allow re-running prepare release branch workflow

### DIFF
--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -31,17 +31,16 @@ jobs:
       - prereqs
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          # history is needed to allow fast-forward push below in case
+          # re-running this workflow after merging additional PRs to main
+          fetch-depth: 0
 
       - name: Create release branch
         run: |
           version=$(.github/scripts/get-version.sh)
           if [[ $version =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
             release_branch_name="release/v${version}"
-            release_branch_exists=$(git ls-remote --heads origin refs/heads/$release_branch_name)
-            if [[ $release_branch_exists != "" ]] ; then
-              echo "release branch $release_branch_name already exists"
-              exit 1
-            fi
           else
             echo "unexpected version: $version"
             exit 1


### PR DESCRIPTION
This change removes the check that prevents re-running the prepare release branch workflow when the release branch already exists. And ports over https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/15038.