### PR TITLE
Refine platform test matrix

### DIFF
--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -50,6 +50,9 @@ jobs:
             test-java-version: 17
           - os: windows-latest
             test-java-version: 21
+    defaults:
+      run:
+        shell: bash # Use bash shell on all OSes for consistency
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
As far as macos testing, I'm guessing the important part is that we ensure things work for contributors to this repo, so probably good enough to only test on latest Java LTS(?)

Windows production servers are more of a reality, but I think it's probably ok to limit our testing to latest Java LTS there as well.