### PR TITLE
Modernize/simplify JUnit Gradle configuration

### DIFF
--- a/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-conventions.gradle.kts
@@ -131,15 +131,12 @@ dependencies {
 
 testing {
   suites.withType(JvmTestSuite::class).configureEach {
+    useJUnitJupiter("5.14.0")
+
     dependencies {
       implementation(project(project.path))
-      implementation(enforcedPlatform("org.junit:junit-bom:5.14.1"))
-      implementation(enforcedPlatform("org.assertj:assertj-bom:3.27.6"))
 
-      implementation("org.junit.jupiter:junit-jupiter-api")
-      implementation("org.junit.jupiter:junit-jupiter-params")
-      runtimeOnly("org.junit.jupiter:junit-jupiter-engine")
-      runtimeOnly("org.junit.platform:junit-platform-launcher")
+      implementation(enforcedPlatform("org.assertj:assertj-bom:3.27.6"))
 
       implementation("org.assertj:assertj-core")
     }


### PR DESCRIPTION
Use useJUnitJupiter() which automatically adds the necessary JUnit dependencies, removing the need to explicitly declare junit-bom, junit-jupiter-api, junit-jupiter-params, junit-jupiter-engine, and junit-platform-launcher.