### PR TITLE
Split kotlin renovate updates from patch group (#17641)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,6 +30,17 @@
       ],
       groupName: 'github actions',
     },
+    {
+      // keep Kotlin Gradle plugin updates out of the catch-all patch PR because CodeQL often
+      // fails on them, which blocks unrelated patch updates
+      matchDepNames: [
+        'org.jetbrains.kotlin.jvm',
+      ],
+      schedule: [
+        '* 0-7 * * 2', // weekly, before 8am on Tuesday
+      ],
+      groupName: 'kotlin plugin updates',
+    },
 
     // ── Disabled updates ───────────────────────────────────────────────
 


### PR DESCRIPTION
Ported from https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/17641