### PR TITLE
Fix duplicate changelog entry in post-release PR

### DIFF
--- a/.github/scripts/merge-change-log-after-release.sh
+++ b/.github/scripts/merge-change-log-after-release.sh
@@ -4,41 +4,29 @@
 # the release date for $VERSION should be available in $RELEASE_DATE
 # and the release notes for $VERSION should be available in /tmp/changelog-section.md
 
-if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.0 ]]; then
-  # this was not a patch release, so the version exists already in the CHANGELOG.md
+# NOTE: this script differs from the equivalent in other Java repos (where it
+# was copied from). In those repos patch releases are cut from the prior
+# minor's release branch, so the patch version heading is not yet present in
+# CHANGELOG.md on main and must be prepended here. In this repo, patch
+# releases also go through the prepare-release-branch workflow, which already
+# adds the heading to main, so we always take the "heading already exists"
+# path below (both for minor and patch releases). Please preserve this
+# difference when syncing workflow changes from other Java repos.
 
-  # update the release date
-  sed -Ei "s/## Version $VERSION .*/## Version $VERSION ($RELEASE_DATE)/" CHANGELOG.md
+# update the release date
+sed -Ei "s/## Version $VERSION .*/## Version $VERSION ($RELEASE_DATE)/" CHANGELOG.md
 
-  # the entries are copied over from the release branch to support workflows
-  # where change log entries may be updated after preparing the release branch
+# the entries are copied over from the release branch to support workflows
+# where change log entries may be updated after preparing the release branch
 
-  {
-    # copy the portion above the release, up to and including the heading
-    sed -n "0,/^## Version $VERSION /p" CHANGELOG.md
-    # copy the release notes for $VERSION
-    cat /tmp/changelog-section.md
-    # copy the portion below the release
-    sed -n "0,/^## Version $VERSION /d;0,/^## Version /{/^## Version/!d};p" CHANGELOG.md
-  } > /tmp/CHANGELOG.md
+{
+  # copy the portion above the release, up to and including the heading
+  sed -n "0,/^## Version $VERSION /p" CHANGELOG.md
+  # copy the release notes for $VERSION
+  cat /tmp/changelog-section.md
+  # copy the portion below the release
+  sed -n "0,/^## Version $VERSION /d;0,/^## Version /{/^## Version/!d};p" CHANGELOG.md
+} > /tmp/CHANGELOG.md
 
-  # update the real CHANGELOG.md
-  cp /tmp/CHANGELOG.md CHANGELOG.md
-
-else
-  # this was a patch release, so the version does not exist already in the CHANGELOG.md
-
-  {
-    # copy the portion above the top-most release, not including the heading
-    sed -n "0,/^## Version /{ /^## Version /!p }" CHANGELOG.md
-    # add the heading
-    echo "## Version $VERSION ($RELEASE_DATE)"
-    # copy the release notes for $VERSION
-    cat /tmp/changelog-section.md
-    # copy the portion starting from the top-most release
-    sed -n "/^## Version /,\$p" CHANGELOG.md
-  } > /tmp/CHANGELOG.md
-
-  # update the real CHANGELOG.md
-  cp /tmp/CHANGELOG.md CHANGELOG.md
-fi
+# update the real CHANGELOG.md
+cp /tmp/CHANGELOG.md CHANGELOG.md


### PR DESCRIPTION
The post-release workflow generated a duplicate `## Version 1.41.1` heading in #479. Root cause:

[`merge-change-log-after-release.sh`](.github/scripts/merge-change-log-after-release.sh) was copied from other Java repos where patch releases are cut from the prior minor's release branch (so the patch heading is not yet on `main` and must be prepended). In this repo, patch releases also go through the `prepare-release-branch` workflow, which already adds the heading to `main` — so the "patch release" branch prepended a second copy.

1.41.1 was the first patch release this repo cut via this workflow, which is why this only surfaced now.

This PR removes the patch-vs-minor conditional (always take the "heading already exists" path) and adds a comment explaining the divergence from other Java repos so it isn't accidentally re-synced.