### PR TITLE
chore: upgrade flint link checks to v0.22.2

### DIFF
--- a/.github/config/lychee.toml
+++ b/.github/config/lychee.toml
@@ -7,7 +7,7 @@ max_retries = 6
 max_concurrency = 4
 
 # Check link anchors
-include_fragments = true
+include_fragments = "anchor-only"
 
 exclude = [
   "^https://github.com/.*#discussion_r.*$",

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-lychee = "0.23.0"
+lychee = "0.24.2"
 
 [settings]
 # Only install tools explicitly defined in the [tools] section above
@@ -14,4 +14,4 @@ use_file_shell_for_executable_tasks = true
 # Pick the tasks you need from flint (https://github.com/grafana/flint)
 [tasks."lint:links"]
 description = "Check for broken links in changed files + all local links"
-file = "https://raw.githubusercontent.com/grafana/flint/eded4cd370c729289a6de327a1a26831e10a39b9/tasks/lint/links.sh" # v0.20.2
+file = "https://raw.githubusercontent.com/grafana/flint/8b7082196051b576d0b8dde43e26d620e7c277b3/tasks/lint/links.sh" # v0.22.2


### PR DESCRIPTION
## What changed
- updated the pinned Flint `links.sh` task to `v0.22.2`
- upgraded `lychee` to `0.24.2`
- switched `lychee` config from `include_fragments = true` to `include_fragments = "anchor-only"`

## Why
These repos consume Flint via pinned remote link-check tasks rather than a local Flint runtime. This rolls them forward to the current link-check task behavior and the newer `lychee` config shape.

## Notes
- no content rewrites were needed
- this keeps the rollout scoped to link-check tooling only

## Validation
- `mise run lint:links --base origin/main --head HEAD`
