### PR TITLE
chore: upgrade flint to v0.22.2

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 
 # Linters
-"github:grafana/flint" = "0.21.0"
+"aqua:grafana/flint" = "0.22.2"
 lychee = "0.24.2"
 
 [tasks.lint]


### PR DESCRIPTION
## What changed
- upgraded the Flint runtime in `mise.toml` to `aqua:grafana/flint@0.22.2`

## Validation
- `mise run lint`
