### PR TITLE
Use protected environment for publishing secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   release:
+    environment: protected
     permissions:
       contents: write # for creating the release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use the protected environment for release jobs that read publishing secrets.

I added the new env and secrets, will wait to remove the existing ones until after this is merged.