### PR TITLE
Add base to root module to enable ./gradlew clean

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ import java.time.Duration
 plugins {
   id("de.undercouch.download")
   id("io.github.gradle-nexus.publish-plugin")
+  base
 }
 
 // start - updated by ./.github/workflows/prepare-release-branch.yml
@@ -159,7 +160,7 @@ val generateSemanticConventions by tasks.registering {
   dependsOn(tasks.getByName("checkSchemaUrls"))
 }
 
-tasks.register("build") {
+tasks.named("build") {
   dependsOn(tasks.getByName("checkSchemaUrls"))
 }
 


### PR DESCRIPTION
If you've got the project checked out locally, and try to run the commands from CONTRIBUTING.md after a semconv version update, then gradle uses the existing semconv download from build/ instead of downloading a new one:

```
./gradlew clean generateSemanticConventions --console=plain
./gradlew spotlessApply
```

There is probably more work to do with properly specifying gradle task input/outputs such that when `var semanticConventionsVersion = 1.42.0` and only `build/semantic-conventions-1.41.1` exists, the `downloadSemanticConventions` task knows it needs to download `build/semantic-conventions-1.42.0`. But the simplest / immediate fix is to make sure the clean task from `./gradlew clean generateSemanticConventions --console=plain` actually deletes `build/` and everything in it.