### PR TITLE
Add failure issue notifications

### DIFF
--- a/.github/workflows/auto-update-semconv.yml
+++ b/.github/workflows/auto-update-semconv.yml
@@ -113,3 +113,18 @@ jobs:
           git add CHANGELOG.md
           git commit -m "Update changelog PR link"
           git push
+
+  workflow-notification:
+    permissions:
+      issues: write
+    needs:
+      - check-versions
+      - update-semconv
+    if: always()
+    uses: open-telemetry/shared-workflows/.github/workflows/workflow-failure-issue.yml@7c49790392da7de86fdb4bb968446f9cb8461eb8 # v0.3.1
+    with:
+      success: >-
+        ${{
+          needs.check-versions.result == 'success' &&
+          (needs.update-semconv.result == 'success' || needs.update-semconv.result == 'skipped')
+        }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,3 +63,13 @@ jobs:
         uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{matrix.language}}"
+
+  workflow-notification:
+    permissions:
+      issues: write
+    needs:
+      - analyze
+    if: always() && github.event_name == 'schedule'
+    uses: open-telemetry/shared-workflows/.github/workflows/workflow-failure-issue.yml@7c49790392da7de86fdb4bb968446f9cb8461eb8 # v0.3.1
+    with:
+      success: ${{ needs.analyze.result == 'success' }}

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -18,3 +18,13 @@ jobs:
         with:
           api-key: ${{secrets.FOSSA_API_KEY}}
           team: OpenTelemetry
+
+  workflow-notification:
+    permissions:
+      issues: write
+    needs:
+      - fossa
+    if: always()
+    uses: open-telemetry/shared-workflows/.github/workflows/workflow-failure-issue.yml@7c49790392da7de86fdb4bb968446f9cb8461eb8 # v0.3.1
+    with:
+      success: ${{ needs.fossa.result == 'success' }}

--- a/.github/workflows/issue-management-stale-action.yml
+++ b/.github/workflows/issue-management-stale-action.yml
@@ -65,3 +65,13 @@ jobs:
           stale-pr-message: >
             This PR has been labeled as stale due to lack of activity.
             It will be automatically closed if there is no further activity over the next 14 days.
+
+  workflow-notification:
+    permissions:
+      issues: write
+    needs:
+      - stale
+    if: always()
+    uses: open-telemetry/shared-workflows/.github/workflows/workflow-failure-issue.yml@7c49790392da7de86fdb4bb968446f9cb8461eb8 # v0.3.1
+    with:
+      success: ${{ needs.stale.result == 'success' }}

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -47,3 +47,13 @@ jobs:
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: results.sarif
+
+  workflow-notification:
+    permissions:
+      issues: write
+    needs:
+      - analysis
+    if: always()
+    uses: open-telemetry/shared-workflows/.github/workflows/workflow-failure-issue.yml@7c49790392da7de86fdb4bb968446f9cb8461eb8 # v0.3.1
+    with:
+      success: ${{ needs.analysis.result == 'success' }}


### PR DESCRIPTION
Add failure issue notifications to scheduled workflows and workflows that run only on pushes to `main`, making failures visible to the full team instead of relying on GitHub’s limited scheduled-workflow notifications.