### PR TITLE
Pin japicmp baseline with apidiff snapshots

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,8 +188,11 @@ jobs:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
         run: |
           ./gradlew japicmp -PapiBaseVersion=$PRIOR_VERSION -PapiNewVersion=$VERSION
+          # Pin the apidiff baseline to the just-released version.
+          sed -i "s/^val apidiffBaselineVersion = .*/val apidiffBaselineVersion = \"$VERSION\"/" build.gradle.kts
           ./gradlew --refresh-dependencies japicmp
           git add docs/apidiffs
+          git add build.gradle.kts
 
       - name: Use CLA approved bot
         run: .github/scripts/use-cla-approved-bot.sh

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 // start - updated by ./.github/workflows/prepare-release-branch.yml
 val snapshot = true
 // end
+val apidiffBaselineVersion = "1.43.0"
 
 // The release version of https://github.com/open-telemetry/semantic-conventions used to generate classes
 var semanticConventionsVersion = "1.43.0"
@@ -51,6 +52,7 @@ allprojects {
     ver += "-SNAPSHOT"
   }
   version = ver
+  extra["apidiffBaselineVersion"] = apidiffBaselineVersion
 }
 
 nexusPublishing {

--- a/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.japicmp-conventions.gradle.kts
@@ -11,18 +11,11 @@ plugins {
 }
 
 /**
- * The latest *released* version of the project. Evaluated lazily so the work is only done if necessary.
+ * The baseline version japicmp compares against. Pinned in build.gradle.kts and bumped
+ * atomically with docs/apidiffs/current_vs_latest/ by the post-release PR opened from
+ * .github/workflows/release.yml.
  */
-val latestReleasedVersion: String by lazy {
-  // hack to find the current released version of the project
-  val temp: Configuration = configurations.create("tempConfig")
-  temp.resolutionStrategy.cacheDynamicVersionsFor(0, TimeUnit.SECONDS)
-  dependencies.add(temp.name, "io.opentelemetry.semconv:opentelemetry-semconv:latest.release")
-  val moduleVersion = configurations["tempConfig"].resolvedConfiguration.firstLevelModuleDependencies.elementAt(0).moduleVersion
-  configurations.remove(temp)
-  logger.debug("Discovered latest release version: " + moduleVersion)
-  moduleVersion
-}
+val apidiffBaselineVersion = rootProject.extra["apidiffBaselineVersion"] as String
 
 class SourceIncompatibleRule : AbstractRecordingSeenMembers() {
   override fun maybeAddViolation(member: JApiCompatibility): Violation? {
@@ -71,9 +64,9 @@ if (!project.hasProperty("otel.release")) {
         // only output changes, not everything
         onlyModified.set(true)
 
-        // the japicmp "old" version is either the user-specified one, or the latest release.
+        // the japicmp "old" version is either the user-specified one, or the pinned baseline.
         val apiBaseVersion: String? by project
-        val baselineVersion = apiBaseVersion ?: latestReleasedVersion
+        val baselineVersion = apiBaseVersion ?: apidiffBaselineVersion
          oldClasspath.from(
             try {
               files(findArtifact(baselineVersion))


### PR DESCRIPTION
Pin the API diff baseline in `version.gradle.kts` and update it together with the API diff files after each release. This prevents a new release from breaking API diff checks on open PRs.

Port of open-telemetry/opentelemetry-java-instrumentation#18391.