### PR TITLE
Reduce Gradle cache writers and converge on Develocity

### DIFF
--- a/.github/workflows/auto-update-semconv.yml
+++ b/.github/workflows/auto-update-semconv.yml
@@ -80,6 +80,8 @@ jobs:
           java-version: 21
 
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       - name: Generate code
         run: ./gradlew clean generateSemanticConventions --console=plain

--- a/.github/workflows/build-common.yml
+++ b/.github/workflows/build-common.yml
@@ -74,6 +74,28 @@ jobs:
           java-version: 21
 
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: >-
+            ${{
+              inputs.cache-read-only ||
+              secrets.DEVELOCITY_ACCESS_KEY == '' ||
+              github.ref_name != github.event.repository.default_branch ||
+              (matrix.os == 'ubuntu-latest' && matrix.test-java-version != 21) ||
+              (matrix.os == 'macos-latest' && matrix.test-java-version != 25) ||
+              (matrix.os == 'windows-latest' && matrix.test-java-version != 25)
+            }}
+          gradle-home-cache-excludes: >-
+            ${{
+              secrets.DEVELOCITY_ACCESS_KEY != '' &&
+              github.ref_name == github.event.repository.default_branch &&
+              (
+                (matrix.os == 'ubuntu-latest' && matrix.test-java-version == 21) ||
+                (matrix.os == 'macos-latest' && matrix.test-java-version == 25) ||
+                (matrix.os == 'windows-latest' && matrix.test-java-version == 25)
+              ) &&
+              'caches/build-cache-1' ||
+              ''
+            }}
 
       - name: build
         shell: bash
@@ -127,4 +149,3 @@ jobs:
             echo $(git diff --cached)
             exit 1
           fi
-

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,8 @@ jobs:
         # but does not build or publish release artifacts.
         if: matrix.language == 'java'
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ permissions:
 jobs:
   build:
     uses: ./.github/workflows/build-common.yml
+    with:
+      cache-read-only: true
     secrets:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
@@ -38,6 +40,8 @@ jobs:
           java-version: 21
 
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       - name: Build and publish artifacts
         run: ./gradlew assemble publishToSonatype closeAndReleaseSonatypeStagingRepository
@@ -188,6 +192,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       - name: Update apidiff baseline
         env:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,9 @@ dependencyResolutionManagement {
 val develocityServer = "https://develocity.opentelemetry.io"
 val isCI = System.getenv("CI") != null
 val develocityAccessKey = System.getenv("DEVELOCITY_ACCESS_KEY") ?: ""
+val isRemoteBuildCachePushEnabled = isCI && develocityAccessKey.isNotEmpty()
+val shouldDisableLocalBuildCache =
+  isRemoteBuildCachePushEnabled && System.getenv("GITHUB_REF_NAME") == "main"
 
 // if develocity access key is not given and we are in CI, then we publish to scans.gradle.com
 val useScansGradleCom = isCI && develocityAccessKey.isEmpty()
@@ -50,8 +53,14 @@ develocity {
 
 if (!useScansGradleCom) {
   buildCache {
+    // A task loaded from the local build cache is never pushed to the remote build cache. Disable
+    // the local cache for authenticated main builds so executed tasks populate Develocity.
+    local {
+      isEnabled = !shouldDisableLocalBuildCache
+    }
+
     remote(develocity.buildCache) {
-      isPush = isCI && develocityAccessKey.isNotEmpty()
+      isPush = isRemoteBuildCachePushEnabled
     }
   }
 }


### PR DESCRIPTION
Applies the cache fixes from [opentelemetry-java-instrumentation#19532](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19532) and [opentelemetry-java-instrumentation#19533](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19533) to reduce GitHub Actions cache pressure and improve Develocity remote cache coverage.