### PR TITLE
Group minor updates with patch updates in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,6 +12,7 @@
 
     {
       // group all patch and minor updates into a single weekly PR
+      // (OpenTelemetry artifacts are excluded so that dogfooding and cascaded releases land individually)
       groupName: 'all patch and minor versions',
       matchUpdateTypes: [
         'patch',
@@ -19,6 +20,10 @@
       ],
       schedule: [
         '* 0-7 * * 2', // weekly, before 8am on Tuesday
+      ],
+      matchPackageNames: [
+        '!io.opentelemetry**',
+        '!open-telemetry/**',
       ],
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,10 +11,11 @@
     // ── Scheduling & grouping ──────────────────────────────────────────
 
     {
-      // group all patch updates into a single weekly PR
-      groupName: 'all patch versions',
+      // group all patch and minor updates into a single weekly PR
+      groupName: 'all patch and minor versions',
       matchUpdateTypes: [
         'patch',
+        'minor',
       ],
       schedule: [
         '* 0-7 * * 2', // weekly, before 8am on Tuesday


### PR DESCRIPTION
Renovate now groups minor updates into the same weekly PR as patch updates, instead of opening a separate PR for every minor release. Today each minor release lands on its own the moment it ships, which produced 27 ungrouped PRs in the last 90 days.

Two dependencies show the cost clearly: checkstyle went 13.5 through 13.9 as five separate PRs, and com.diffplug.spotless went 8.6 through 8.10 as five more. Under this rule each of those would have been folded into the weekly group.

This matches what opentelemetry-java already does. Major updates are unaffected and still get their own PR.

OpenTelemetry artifacts are excluded from the group. They keep arriving individually and immediately, which is what dogfooding and cascaded releases need, and that applies to their patch updates as well.

The exclusion needs both patterns: `io.opentelemetry**` covers every OpenTelemetry Maven group id, and `open-telemetry/**` covers GitHub-sourced dependencies such as `open-telemetry/semantic-conventions`.

`otel/weaver` and other OpenTelemetry Docker images stay in the group, because they are test infrastructure rather than cascaded releases.

The 'flint-managed linter updates' minors will also fold into the weekly group, because this repo's packageRules are applied after the grafana/flint preset.