### PR TITLE
Group minor updates with patch updates in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,6 +12,7 @@
 
     {
       // group all patch and minor updates into a single weekly PR
+      // (OpenTelemetry artifacts are excluded so that dogfooding and cascaded releases land individually)
       groupName: 'all patch and minor versions',
       matchUpdateTypes: [
         'patch',
@@ -19,6 +20,10 @@
       ],
       schedule: [
         '* 0-7 * * 2', // weekly, before 8am on Tuesday
+      ],
+      matchPackageNames: [
+        '!io.opentelemetry**',
+        '!open-telemetry/**',
       ],
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,10 +11,11 @@
     // ── Scheduling & grouping ──────────────────────────────────────────
 
     {
-      // group all patch updates into a single weekly PR
-      groupName: 'all patch versions',
+      // group all patch and minor updates into a single weekly PR
+      groupName: 'all patch and minor versions',
       matchUpdateTypes: [
         'patch',
+        'minor',
       ],
       schedule: [
         '* 0-7 * * 2', // weekly, before 8am on Tuesday


### PR DESCRIPTION
Renovate now groups minor updates into the same weekly pull request as patch updates, instead of opening one for every minor release the moment it ships. That was 27 ungrouped pull requests in the last 90 days: checkstyle took five to go from 13.5 to 13.9, and spotless five more to go from 8.6 to 8.10.

OpenTelemetry updates are excluded and keep arriving individually and immediately, including their patch updates, which is what dogfooding and cascaded releases need.

`otel/weaver` and other OpenTelemetry images stay in the group, since they are test infrastructure rather than cascaded releases.

Major updates are unaffected and still get their own pull request. This matches what opentelemetry-java already does.
